### PR TITLE
提供CloudFlare部署方法

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,9 +37,11 @@ deno run --allow-net --allow-read --allow-env --watch main.ts
 ```
 
 ## 自己部署
-
+### Demo
 点击[这个链接][1]，可以快速一键部署到 Deno Deploy 上。
 
 然后在 Settings 选项卡里可以设置自定义二级域名，或者绑定自己的域名。
 
 [1]: https://dash.deno.com/new?url=https://raw.githubusercontent.com/justjavac/openai-proxy/main/main.ts
+### CloudFlare
+将Cloudflare.ts复制到CloudFlare Workers中

--- a/Readme.md
+++ b/Readme.md
@@ -43,5 +43,7 @@ deno run --allow-net --allow-read --allow-env --watch main.ts
 然后在 Settings 选项卡里可以设置自定义二级域名，或者绑定自己的域名。
 
 [1]: https://dash.deno.com/new?url=https://raw.githubusercontent.com/justjavac/openai-proxy/main/main.ts
+
 ### CloudFlare
-将Cloudflare.ts复制到CloudFlare Workers中
+
+将 cloudflare.ts 复制到 CloudFlare Workers 中。

--- a/cloudflare.ts
+++ b/cloudflare.ts
@@ -1,17 +1,19 @@
 //copy this to cloudflare workers
 export default {
-    async fetch(request) {
+    async fetch(request, env) {
         try {
             const OPENAI_API_HOST = "api.openai.com";
-            const proxy = new URL(request.url);
+            const oldUrl = new URL(request.url);
 
-            if (proxy.hostname === "/") {
-                return new Response(`https://${proxy.hostname}/v1`, {status: 200});
+
+            if (oldUrl.pathname === "/") {
+                return new Response(`https://${oldUrl.hostname}/v1`, {status: 200});
             }
 
-            proxy.hostname = OPENAI_API_HOST;
+            const newUrl = new URL(request.url);
+            newUrl.hostname = OPENAI_API_HOST;
 
-            const modifiedRequest = new Request(proxy, {
+            const modifiedRequest = new Request(newUrl, {
                 method: request.method,
                 headers: request.headers,
                 body: request.body
@@ -23,3 +25,4 @@ export default {
         }
     }
 }
+

--- a/cloudflare.ts
+++ b/cloudflare.ts
@@ -1,0 +1,25 @@
+//copy this to cloudflare workers
+export default {
+    async fetch(request) {
+        try {
+            const OPENAI_API_HOST = "api.openai.com";
+            const proxy = new URL(request.url);
+
+            if (proxy.hostname === "/") {
+                return new Response(`https://${proxy.hostname}/v1`, {status: 200});
+            }
+
+            proxy.hostname = OPENAI_API_HOST;
+
+            const modifiedRequest = new Request(proxy, {
+                method: request.method,
+                headers: request.headers,
+                body: request.body
+            });
+
+            return await fetch(modifiedRequest);
+        } catch (e) {
+            return new Response(e.stack, {status: 500});
+        }
+    }
+}


### PR DESCRIPTION
Deno进行使用中经常报错，使用CloudFlare后无此问题。
```
TypeError: error sending request for url (https://api.openai.com/v1/chat/completions): http2 error: stream error received: unspecific protocol error detected
    at async mainFetch (ext:deno_fetch/26_fetch.js:266:12)
    at async fetch (ext:deno_fetch/26_fetch.js:490:7)
    at async Server.<anonymous> (https://raw.githubusercontent.com/justjavac/openai-proxy/main/main.ts:13:10)
    at async Server.#respond (https://deno.land/std@0.181.0/http/server.ts:299:18)
```
CloudFlare同样提供每天10W次免费额度