### PR TITLE
refactor: use Deno.serve

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,3 @@
-import { serve } from "https://deno.land/std@0.181.0/http/server.ts";
-
-serve(() => {
+Deno.serve(() => {
   return fetch(new URL("./Readme.md", import.meta.url));
 });


### PR DESCRIPTION
`std/http/server.ts` is now deprecated. We should use Deno.serve instead.